### PR TITLE
Fix parsing of call expression arguments

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -289,7 +289,7 @@ module.exports = grammar({
       $.global_variable,
       $._variable_declarator,
       prec(-1, alias($.function_call_statement, $.function_call)),
-      seq('(', $._expression, ')')
+      seq('(', optional(commaSeq($._expression)), ')')
     ),
 
     // Expressions: Function definition

--- a/grammar.js
+++ b/grammar.js
@@ -90,6 +90,7 @@ module.exports = grammar({
 
     _variable_declarator: $ => choice(
       $.identifier,
+      $.self,
       seq($._prefix, '[', $._expression, ']'),
       $.field_expression
     ),
@@ -258,8 +259,6 @@ module.exports = grammar({
       $.spread,
       $._prefix,
 
-      $.next,
-
       $.function_definition,
 
       $.table,
@@ -280,16 +279,10 @@ module.exports = grammar({
 
     self: $ => 'self',
 
-    next: $ => 'next',
-
-    global_variable: $ => choice('_G', '_VERSION'),
-
     _prefix: $ => choice(
-      $.self,
-      $.global_variable,
       $._variable_declarator,
       prec(-1, alias($.function_call_statement, $.function_call)),
-      seq('(', optional(commaSeq($._expression)), ')')
+      seq('(', $._expression, ')')
     ),
 
     // Expressions: Function definition

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -1210,10 +1210,6 @@
         },
         {
           "type": "SYMBOL",
-          "name": "next"
-        },
-        {
-          "type": "SYMBOL",
           "name": "function_definition"
         },
         {
@@ -1261,10 +1257,6 @@
     "self": {
       "type": "STRING",
       "value": "self"
-    },
-    "next": {
-      "type": "STRING",
-      "value": "next"
     },
     "global_variable": {
       "type": "CHOICE",

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -36,10 +36,6 @@
           "named": true
         },
         {
-          "type": "next",
-          "named": true
-        },
-        {
           "type": "nil",
           "named": true
         },
@@ -111,10 +107,6 @@
           "named": true
         },
         {
-          "type": "next",
-          "named": true
-        },
-        {
           "type": "nil",
           "named": true
         },
@@ -183,10 +175,6 @@
         },
         {
           "type": "identifier",
-          "named": true
-        },
-        {
-          "type": "next",
           "named": true
         },
         {
@@ -490,10 +478,6 @@
           "named": true
         },
         {
-          "type": "next",
-          "named": true
-        },
-        {
           "type": "nil",
           "named": true
         },
@@ -565,10 +549,6 @@
           "named": true
         },
         {
-          "type": "next",
-          "named": true
-        },
-        {
           "type": "nil",
           "named": true
         },
@@ -637,10 +617,6 @@
         },
         {
           "type": "identifier",
-          "named": true
-        },
-        {
-          "type": "next",
           "named": true
         },
         {
@@ -965,10 +941,6 @@
         },
         {
           "type": "method",
-          "named": true
-        },
-        {
-          "type": "next",
           "named": true
         },
         {
@@ -1376,10 +1348,6 @@
           "named": true
         },
         {
-          "type": "next",
-          "named": true
-        },
-        {
           "type": "nil",
           "named": true
         },
@@ -1452,10 +1420,6 @@
         },
         {
           "type": "identifier",
-          "named": true
-        },
-        {
-          "type": "next",
           "named": true
         },
         {
@@ -1707,10 +1671,6 @@
           "named": true
         },
         {
-          "type": "next",
-          "named": true
-        },
-        {
           "type": "nil",
           "named": true
         },
@@ -1797,10 +1757,6 @@
           "named": true
         },
         {
-          "type": "next",
-          "named": true
-        },
-        {
           "type": "nil",
           "named": true
         },
@@ -1869,10 +1825,6 @@
         },
         {
           "type": "identifier",
-          "named": true
-        },
-        {
-          "type": "next",
           "named": true
         },
         {
@@ -1948,10 +1900,6 @@
         },
         {
           "type": "identifier",
-          "named": true
-        },
-        {
-          "type": "next",
           "named": true
         },
         {
@@ -2242,10 +2190,6 @@
   },
   {
     "type": "method",
-    "named": true
-  },
-  {
-    "type": "next",
     "named": true
   },
   {


### PR DESCRIPTION
The call expression isn't right, which causes a parse error.

It should allow for no or multiple arguments, not only a single argument.