### PR TITLE
SPM  support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ package-lock.json
 Cargo.lock
 
 /build
+/.build
 /target
 *.obj
 *.exp

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,31 @@
+// swift-tools-version:5.3
+
+import PackageDescription
+
+let package = Package(
+    name: "TreeSitterLua",
+    platforms: [.macOS(.v10_13), .iOS(.v11)],
+    products: [
+        .library(name: "TreeSitterLua", targets: ["TreeSitterLua"]),
+    ],
+    dependencies: [],
+    targets: [
+        .target(name: "TreeSitterLua",
+                path: ".",
+                exclude: [
+                    "binding.gyp",
+                    "bindings",
+                    "Cargo.toml",
+                    "grammar.js",
+                    "LICENSE.txt",
+                    "package.json",
+                    "README.md",
+                ],
+                sources: [
+                    "src/parser.c",
+                    "src/scanner.c",
+                ],
+                publicHeadersPath: "bindings/swift",
+                cSettings: [.headerSearchPath("src")])
+    ]
+)

--- a/bindings/swift/TreeSitterLua/lua.h
+++ b/bindings/swift/TreeSitterLua/lua.h
@@ -1,0 +1,16 @@
+#ifndef TREE_SITTER_LUA_H_
+#define TREE_SITTER_LUA_H_
+
+typedef struct TSLanguage TSLanguage;
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+extern TSLanguage *tree_sitter_lua();
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // TREE_SITTER_LUA_H_


### PR DESCRIPTION
This PR adds Swift package manager support, so the parser can be more easily integrated with and used from Swift. While not necessary, it does pair nicely with [SwiftTreeSitter](https://github.com/ChimeHQ/SwiftTreeSitter).

Typically, when we make a Swift package for a tree-sitter parser, it includes queries as well. I noticed there aren't any here, so I've omitted that. But, should any ever be added, the Package.swift file will have to be changed again. Not a big deal, just letting you know.

Thanks so much for maintaining this package - it's awesome!